### PR TITLE
fix " '~' on a boolean expression" error for qce50.c

### DIFF
--- a/drivers/crypto/msm/qce50.c
+++ b/drivers/crypto/msm/qce50.c
@@ -4620,7 +4620,7 @@ again:
 			pce_dev->intr_cadence = 0;
 			atomic_set(&pce_dev->bunch_cmd_seq, 0);
 			atomic_set(&pce_dev->last_intr_seq, 0);
-			pce_dev->cadence_flag = ~pce_dev->cadence_flag;
+			pce_dev->cadence_flag = !pce_dev->cadence_flag;
 		}
 	}
 


### PR DESCRIPTION
change drivers/crypto/msm/qce.50 line 4423 "pce_dev->cadence_flag = ~pce_dev->cadence_flag;" to "pce_dev->cadence_flag = !pce_dev->cadence_flag;"