### PR TITLE
fix misleading-indentation error in drivers/input/touchscreen/nubia_s…

### DIFF
--- a/drivers/input/touchscreen/nubia_synaptics_dsx/synaptics_dsx_i2c.c
+++ b/drivers/input/touchscreen/nubia_synaptics_dsx/synaptics_dsx_i2c.c
@@ -117,7 +117,7 @@ static int parse_dt(struct device *dev, struct synaptics_dsx_board_data *bdata)
 	else
 		bdata->bus_reg_name = name;
 
-		bdata->power_gpio = of_get_named_gpio_flags(np,
+	bdata->power_gpio = of_get_named_gpio_flags(np,
 				"synaptics,power-gpio", 0, NULL);
 	if (bdata->power_gpio < 0){
 		bdata->power_gpio = -1;


### PR DESCRIPTION
…ynaptics_dsx/synaptics_dsx_i2c.c

move line 120 slightly to avoid misleading-indentation error