### PR TITLE
fix bool-compare error in sound/soc/codecs/tfa_container.c

### DIFF
--- a/sound/soc/codecs/tfa_container.c
+++ b/sound/soc/codecs/tfa_container.c
@@ -289,7 +289,7 @@ int tfaContWriteRegsProf(struct tfa98xx *tfa98xx, int profile)
 			err = tfaRunWriteBitfield(tfa98xx, tfaContDsc2Bf(prof->list[i]));
 		}
 
-		if (!prof->list[i].type == dscRegister) {
+		if ((!prof->list[i].type) == dscRegister) {
 			err = tfaRunWriteRegister(tfa98xx, (struct nxpTfaRegpatch *)(base + prof->list[i].offset));
 		}
 


### PR DESCRIPTION
change tfa_container.c line 292 "if (!prof->list[i].type == dscRegister)" to "if ((!prof->list[i].type) == dscRegister)" to avoid bool-compare error